### PR TITLE
Allow adding custom field with NULL to clear it.

### DIFF
--- a/src/Issue/IssueField.php
+++ b/src/Issue/IssueField.php
@@ -155,7 +155,7 @@ class IssueField implements \JsonSerializable
         return $this->customFields;
     }
 
-    public function addCustomField(string $key, string|int|float|array|Document $value): static
+    public function addCustomField(string $key, string|int|float|array|Document|NULL $value): static
     {
         $this->customFields[$key] = $value;
 


### PR DESCRIPTION
In the non-cloud version it was/is possible to add a custom field with a value of NULL, so that it would get cleared no matter the type. The type info in the addCustomField function now prevents that, this just adds NULL to that list to allow it again.